### PR TITLE
feat: add activation quantization and refactor config structure

### DIFF
--- a/compressor/modifier/__init__.py
+++ b/compressor/modifier/__init__.py
@@ -5,3 +5,4 @@ from .reorder import *
 from .gptq import *
 from .rtn import *
 from .weight import *
+from .activation import *

--- a/compressor/modifier/activation/__init__.py
+++ b/compressor/modifier/activation/__init__.py
@@ -1,0 +1,2 @@
+from .base import *
+from .hooks import *

--- a/compressor/modifier/activation/base.py
+++ b/compressor/modifier/activation/base.py
@@ -1,0 +1,117 @@
+import torch
+
+from typing import *
+from loguru import logger
+from dataclasses import dataclass, field
+from pydantic import PrivateAttr
+
+from compressor.config.quant import QuantArgs
+from compressor.calib import CalibDataLoader
+from compressor.nn.struct import LLMStruct, DecoderStruct
+from compressor.modifier.base import Modifier
+from compressor.modifier.activation.hooks import DynamicInputQuantHook, DynamicOutputQuantHook
+
+__all__ = ["ActivationQuantConfig", "ActivationQuantModifier"]
+
+@dataclass
+class ActivationQuantConfig:
+    """
+    Configuration for activation quantization
+    """
+    input_args: Optional[QuantArgs] = field(default=None)
+    output_args: Optional[QuantArgs] = field(default=None)
+    skips: List[str] = field(default_factory=list)
+
+class ActivationQuantModifier(Modifier):
+    """
+    Activation quantization modifier
+
+    - input: per-token dynamic quantization on linear inputs
+    - output: group-wise dynamic quantization on attention outputs
+    """
+    config: ActivationQuantConfig
+
+    # runtime states
+    _model_struct: Optional[LLMStruct] = PrivateAttr(default=None)
+
+    def initialize(self, model_struct: LLMStruct):
+        self._model_struct = model_struct
+        self._initialized = True
+
+    @torch.inference_mode()
+    def apply(
+        self, layer_struct: DecoderStruct, _dataloader: CalibDataLoader
+    ):
+        """
+        Apply dynamic quantization for activations
+        
+        1. Register forward_pre hooks for input activation
+        2. Register forward hooks for output activation
+        2. Quantize activations in real time (online)
+        """
+        if not self._initialized:
+            raise RuntimeError("ActivationQuantModifier is not initialized")
+
+        # get infos
+        attn = layer_struct.attn_struct
+        ffn = layer_struct.ffn_struct
+        skips = set(self.config.skips)
+        input_args = self.config.input_args
+        output_args = self.config.output_args
+
+        # qkv projs
+        for rname in [attn.q_proj_rname, attn.k_proj_rname, attn.v_proj_rname]:
+            proj = getattr(attn, rname, None)
+            if proj is None: continue
+
+            # input
+            if input_args is not None:
+                input_hook = DynamicInputQuantHook(args=input_args)
+                self.register_persistent_hook(
+                    proj, input_hook.as_input_hook(),
+                    "forward_pre", with_kwargs=True
+                )
+
+            # output
+            if output_args is not None and rname not in skips:
+                output_hook = DynamicOutputQuantHook(args=output_args)
+                self.register_persistent_hook(
+                    proj, output_hook.as_output_hook(), "forward"
+                )
+
+        # o proj
+        if input_args is not None and attn.o_proj is not None:
+            input_hook = DynamicInputQuantHook(args=input_args)
+            self.register_persistent_hook(
+                attn.o_proj, input_hook.as_input_hook(),
+                "forward_pre", with_kwargs=True
+            )
+
+        # up projs
+        if input_args is not None:
+            for proj in ffn.up_projs:
+                input_hook = DynamicInputQuantHook(args=input_args)
+                self.register_persistent_hook(
+                    proj, input_hook.as_input_hook(),
+                    "forward_pre", with_kwargs=True
+                )
+
+            # down proj
+            input_hook = DynamicInputQuantHook(args=input_args)
+            self.register_persistent_hook(
+                ffn.down_proj, input_hook.as_input_hook(),
+                "forward_pre", with_kwargs=True
+            )
+    
+    def finalize(self):
+        """
+        Finalize after all layers processed
+        """
+        self._model_struct = None
+        self._initialized = False
+    
+    def debug(self, layer_idx: int):
+        """
+        Log debug information
+        """
+        ...

--- a/compressor/modifier/activation/hooks.py
+++ b/compressor/modifier/activation/hooks.py
@@ -1,0 +1,62 @@
+import torch
+
+from dataclasses import dataclass
+from compressor.config.quant import QuantArgs
+from compressor.observers import Observer
+from compressor.utils import PersistentHook, fake_quantize
+
+__all__ = ["DynamicInputQuantHook", "DynamicOutputQuantHook"]
+
+
+@dataclass
+class DynamicInputQuantHook(PersistentHook):
+    """
+    Forward pre hook for dynamic input activation quantization
+    """
+    args: QuantArgs
+
+    def process(self, x: torch.Tensor):
+        observer_cls = Observer.get(self.args.observer)
+        observer = observer_cls(self.args).to(x.device)
+        scale, zero = observer(x, target="activation")
+        scale, zero = _reshape_scale_zero(scale, zero, self.args.strategy)
+
+        return fake_quantize(x, scale, zero, self.args)
+
+
+@dataclass
+class DynamicOutputQuantHook(PersistentHook):
+    """
+    Forward hook for dynamic output activation quantization
+    """
+    args: QuantArgs
+
+    def process(self, x: torch.Tensor):
+        observer_cls = Observer.get(self.args.observer)
+        observer = observer_cls(self.args).to(x.device)
+        scale, zero = observer(x, target="activation")
+        scale, zero = _reshape_scale_zero(scale, zero, self.args.strategy)
+
+        return fake_quantize(x, scale, zero, self.args)
+
+def _reshape_scale_zero(scale, zero, strategy):
+    """
+    Reshape scale/zero for activation broadcasting
+    """
+    if strategy == "token":
+        # (seq,) -> (1, seq, 1)
+        scale = scale.unsqueeze(0).unsqueeze(-1)
+        zero = zero.unsqueeze(0).unsqueeze(-1)
+    
+    elif strategy == "group":
+        # (seq, num_groups) → (1, seq, num_groups)
+        if scale.ndim == 2:
+            scale = scale.unsqueeze(0)
+            zero = zero.unsqueeze(0)
+
+        # (num_groups,) → (1, 1, num_groups)
+        else:
+            scale = scale.unsqueeze(0).unsqueeze(0)
+            zero = zero.unsqueeze(0).unsqueeze(0)
+
+    return scale, zero

--- a/compressor/modifier/rotate/hadamard.py
+++ b/compressor/modifier/rotate/hadamard.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 from typing import *
 from dataclasses import dataclass
 from scipy.linalg import hadamard
-from compressor.utils import PersistentInputHook
+from compressor.utils import PersistentHook
 
 __all__ = [
     "HadamardMatrix",
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 @dataclass
-class HadamardInputHook(PersistentInputHook):
+class HadamardInputHook(PersistentHook):
     """
     Forward pre hook for Hadamard transformation on down_proj input
     """

--- a/compressor/modifier/weight/base.py
+++ b/compressor/modifier/weight/base.py
@@ -43,6 +43,7 @@ class WeightQuantModifier(Modifier):
         Initialize by creating and initializing the appropriate modifier
         """
         method = self.config.method.lower()
+        
         # create internal modifier
         if method == "gptq":
             from compressor.modifier.gptq import GPTQModifier

--- a/compressor/observers/base.py
+++ b/compressor/observers/base.py
@@ -87,22 +87,13 @@ class Observer(nn.Module, RegistryMixin):
                 return x
             
             # (batch_size * seq_len, num_groups, group_size)
-            elif strategy == "group":
-                return x.flatten(0, 1).unflatten(-1, (-1, self.args.group_size))
-        
-            else:
-                raise ValueError(f"Unsupported strategy {strategy} in {target}")
-        
-        # (batch_size, num_heads, seq_len, head_dim)
-        elif target == "kv_cache":
-            # (batch_size * seq_len, 1, num_heads * head_dim)
-            if strategy == "tensor":
-                return x.transpose(1, 2).flatten(0, 1).flatten(-2, -1).unsqueeze(-2)
+            # elif strategy == "group":
+            #     return x.flatten(0, 1).unflatten(-1, (-1, self.args.group_size))
 
-            # (batch_size * seq_len, num_heads, 1, 1, head_dim)
-            elif strategy == "head":
-                return x.transpose(1, 2).flatten(0, 1).unsqueeze(-2).unsqueeze(-2)
-            
+            # (batch_size, seq_len, num_groups, group_size)
+            elif strategy == "group":
+                return x.unflatten(-1, (-1, self.args.group_size))
+
             else:
                 raise ValueError(f"Unsupported strategy {strategy} in {target}")
 

--- a/examples/configs/gptq.yaml
+++ b/examples/configs/gptq.yaml
@@ -7,16 +7,15 @@ calib:
   seed: 42
 
 quant:
+  path: ""
   weight:
-    bits: 4
-    strategy: "group"
-    group_size: 128
-    symmetric: true
-    observer: "memoryless-minmax"
-  activation: null
-  kv_cache: null
-
-weight_quant:
-  method: "gptq"
-  block_size: 128
-  perc_damp: 0.01
+    args:
+      bits: 4
+      strategy: "group"
+      group_size: 128
+      symmetric: true
+      observer: "memoryless-minmax"
+    mod:
+      method: "gptq"
+      block_size: 128
+      perc_damp: 0.01

--- a/examples/configs/qoq.yaml
+++ b/examples/configs/qoq.yaml
@@ -6,40 +6,57 @@ calib:
   max_length: 0
   seed: 42
 
-rotate:
-  enabled: true
-  random: false
+transform:
   path: ""
-  rotate_out: true   # qoq: rotation.transforms: [out_proj]
-  rotate_down: false # qoq: no Hadamard hook
+  rotate:
+    enabled: false
+    random: false
+    rotate_out: true   
+    rotate_down: false 
 
-reorder:
-  enabled: true
-  path: ""
-  reorder_out: false # qoq: not in reorder.skips
-  reorder_down: true # qoq: not in reorder.skips
+  reorder:
+    enabled: false
+    reorder_out: false 
+    reorder_down: true 
 
-smooth:
-  enabled: true
-  path: ""
-  smooth_attn: true  # qoq: smooth.enable_attn: true
-  smooth_qkv: false  # qoq: smooth.proj.skips: [qkv_proj]
-  smooth_vo: false   # qoq: smooth.proj.skips: [out_proj]
-  smooth_ffn: false  # qoq: smooth.proj.skips: [up_proj]
-  smooth_down: true  # qoq: down_proj not in smooth.proj.skips (applied with reorder_down)
-  alpha: 0.5         # qoq: smooth.attn.alpha: 0.5
+  smooth:
+    enabled: false
+    smooth_attn: true  
+    smooth_qkv: false  
+    smooth_vo: false  
+    smooth_ffn: false 
+    smooth_down: true 
+    alpha: 0.5        
 
 quant:
+  path: ""
   weight:
-    bits: 4
-    strategy: "group"
-    group_size: 128
-    symmetric: true
-    observer: "memoryless-minmax"
-  activation: null
-  kv_cache: null
-
-weight_quant:
-  method: "gptq"
-  block_size: 128
-  perc_damp: 0.01
+    args:
+      bits: 4
+      strategy: "group"
+      group_size: 128
+      symmetric: true
+      observer: "memoryless-minmax"
+    mod:
+      method: "gptq"
+      block_size: 128
+      perc_damp: 0.01
+  
+  input:
+    args:
+      bits: 8
+      symmetric: true
+      strategy: "token"
+      dynamic: true
+      observer: "minmax"
+  
+  output:
+    args:
+      bits: 4
+      symmetric: false
+      strategy: "group"
+      group_size: 128
+      dynamic: true
+      observer: "minmax"
+    mod:
+      skips: "q_proj"

--- a/examples/configs/rtn.yaml
+++ b/examples/configs/rtn.yaml
@@ -7,14 +7,13 @@ calib:
   seed: 42
 
 quant:
+  path: ""
   weight:
-    bits: 4
-    strategy: "group"
-    group_size: 128
-    symmetric: true
-    observer: "memoryless-minmax"
-  activation: null
-  kv_cache: null
-
-weight_quant:
-  method: "rtn"
+    args:
+      bits: 4
+      strategy: "group"
+      group_size: 128
+      symmetric: true
+      observer: "memoryless-minmax"
+    mod:
+      method: "rtn"

--- a/examples/configs/smoothquant.yaml
+++ b/examples/configs/smoothquant.yaml
@@ -6,27 +6,27 @@ calib:
   max_length: 0
   seed: 42
 
-smooth:
-  enabled: true
+transform:
   path: ""
-  smooth_attn: true 
-  smooth_qkv: true  
-  smooth_vo: false   
-  smooth_ffn: true  
-  smooth_down: false  
-  alpha: 0.85         
+  smooth:
+    enabled: true
+    smooth_attn: true
+    smooth_qkv: true
+    smooth_vo: false
+    smooth_ffn: true
+    smooth_down: false
+    alpha: 0.85
 
 quant:
+  path: ""
   weight:
-    bits: 8
-    strategy: "group"
-    group_size: 128
-    symmetric: true
-    observer: "memoryless-minmax"
-  activation: null
-  kv_cache: null
-
-weight_quant:
-  method: "gptq"
-  block_size: 128
-  perc_damp: 0.01
+    args:
+      bits: 8
+      strategy: "group"
+      group_size: 128
+      symmetric: true
+      observer: "memoryless-minmax"
+    mod:
+      method: "gptq"
+      block_size: 128
+      perc_damp: 0.01


### PR DESCRIPTION
This PR implements activation quantization support and refactors the configuration structure to be more flexible.

Key changes:
- Added `ActivationQuantModifier` for dynamic input/output quantization.
- Refactored `CompressorConfig` to support nested `transform` and `quant` sections.
- Renamed `QuantConfig` fields for clarity (`activation` -> `input`).
- Updated example configurations.
- Improved hook utilities with `PersistentHook` supporting both input and output processing.