### PR TITLE
fix: resolve UltraChatDataset errors and refactor rotation precision handling

### DIFF
--- a/compressor/compress.py
+++ b/compressor/compress.py
@@ -59,6 +59,7 @@ class Compressor:
         # initialize modifiers & dataloader
         model_struct = self.dataloader.model_struct
         for modifier in self.modifiers:
+            logger.info(f"Initialize Modifier: {type(modifier).__name__}")
             modifier.initialize(model_struct)
         self.dataloader.initialize()
         logger.info(f"Initialized {len(self.modifiers)} modifiers successfully")
@@ -77,7 +78,7 @@ class Compressor:
 
             # apply modifier
             for modifier in self.modifiers:
-                logger.info(f"Modifier: {type(modifier).__name__}")
+                logger.info(f"Apply Modifier: {type(modifier).__name__}")
                 
                 # clear the memory for debug
                 if LEVEL <= DEBUG:

--- a/compressor/data/__init__.py
+++ b/compressor/data/__init__.py
@@ -3,3 +3,4 @@ from .c4 import *
 from .custom import *
 from .pileval import *
 from .wikitext import *
+from .ultrachat import *

--- a/compressor/modifier/rotate/rotate.py
+++ b/compressor/modifier/rotate/rotate.py
@@ -148,9 +148,7 @@ def convert_ln_to_rms(
     rms = RMSNorm(hidden_size=hidden_size, eps=eps)
 
     # convert to RMSNorm
-    # rms.weight.data = norm.weight.data.clone()
     rms.weight.data = norm.weight.data
-    # rms = rms.to(device=norm.weight.device, dtype=norm.weight.dtype)
     setattr(norm_parent, norm_name, rms)
 
     return rms


### PR DESCRIPTION
## Summary

Closes #5

### UltraChatDataset Bug Fixes
- **Fix AttributeError**: Assign `self.tokenizer = tokenizer` before calling `super().__init__()` so `get_dataset` can access it correctly
- **Remove broken reference**: Delete `self._tokenizer = self.__dict__.get("_init_tokenizer")` which referenced a never-defined attribute
- **Export fix**: Add `from .ultrachat import *` to `compressor/data/__init__.py`
- **Memory optimization**: Reduce shuffle `buffer_size` from 10000 → 500
- **Column cleanup**: Add `dataset.select_columns(["text"])` to drop unnecessary columns after mapping

### Rotation Precision Refactor
- **`move_to_fp32` context manager**: Replace repetitive manual state save/restore pattern with a clean `@contextlib.contextmanager` that temporarily moves `nn.Linear` modules to CPU float32, then restores original device/dtype
- **Scoped precision**: Apply `move_to_fp32` around each individual rotation operation (fuse_ln_fcs, rotate_in/out, hadamard_in) instead of converting the entire model at once — more memory efficient and easier to reason about
- **Dead code removal**: Remove commented-out lines in `rotate.py`

### Minor Improvements
- Improve log messages in `compress.py`: distinguish "Initialize Modifier" from "Apply Modifier"

## Test plan

- [ ] Run calibration with UltraChatDataset — no AttributeError on init
- [ ] Verify rotation + quantization pipeline produces correct PPL on a reference model
- [ ] Confirm no memory regression from scoped fp32 context manager