### PR TITLE
refactor: remove unused path-based caching from quant configs

### DIFF
--- a/compressor/modifier/activation/base.py
+++ b/compressor/modifier/activation/base.py
@@ -18,7 +18,6 @@ class ActivationQuantConfig:
     """
     Configuration for activation quantization
     """
-    path: str = ""
     input_args: Optional[QuantArgs] = field(default=None)
     output_args: Optional[QuantArgs] = field(default=None)
     skips: List[str] = field(default_factory=list)

--- a/compressor/modifier/gptq/base.py
+++ b/compressor/modifier/gptq/base.py
@@ -146,14 +146,7 @@ class GPTQModifier(Modifier):
     def finalize(self):
         """
         Finalize after all layers processed
-
-        1. save quantized params
-        2. reset states
         """
-        # save params
-        if self.config.path and self._qparams:
-            torch.save(self._qparams, self.config.path)
-
         # reset states
         self._model_struct = None
         self._gptq_hooks = {}

--- a/compressor/modifier/weight/base.py
+++ b/compressor/modifier/weight/base.py
@@ -16,8 +16,7 @@ class WeightQuantConfig:
     Configuration for weight quantization
     """
     args: QuantArgs = field(default_factory=QuantArgs)
-
-    path: str = ""
+    
     method: str = "gptq"    # "gptq", "rtn", "awq"
     block_size: int = 128
     perc_damp: float = 0.01

--- a/examples/configs/default.yaml
+++ b/examples/configs/default.yaml
@@ -32,7 +32,6 @@ transform:
     attn_beta: 0
 
 quant:
-  path: "output/qoq/quant"
   weight:
     args:
       bits: 4

--- a/examples/configs/gptq.yaml
+++ b/examples/configs/gptq.yaml
@@ -7,7 +7,6 @@ calib:
   seed: 42
 
 quant:
-  path: ""
   weight:
     args:
       bits: 4

--- a/examples/configs/qoq.yaml
+++ b/examples/configs/qoq.yaml
@@ -32,7 +32,6 @@ transform:
     attn_beta: 0
 
 quant:
-  path: "output/qoq/quant"
   weight:
     args:
       bits: 4

--- a/examples/configs/rtn.yaml
+++ b/examples/configs/rtn.yaml
@@ -7,7 +7,6 @@ calib:
   seed: 42
 
 quant:
-  path: ""
   weight:
     args:
       bits: 4

--- a/examples/configs/smoothquant.yaml
+++ b/examples/configs/smoothquant.yaml
@@ -21,7 +21,6 @@ transform:
     attn_beta: 0
 
 quant:
-  path: ""
   weight:
     args:
       bits: 8


### PR DESCRIPTION
## Summary
- Remove `path` field from `WeightQuantConfig` and `ActivationQuantConfig` — quant results don't benefit from file-based caching unlike transform params (rotate/reorder/smooth)
- Remove `quant_path` field and related path propagation/mkdir logic from `CompressorConfig`
- Remove `torch.save` of `_qparams` in `GPTQModifier.finalize()` — saving is not the modifier's responsibility; future packing will consume scale/zero from pipeline return values
- Remove `quant.path` entries from all example YAML configs
- Fix potential `NameError` for `skips` variable in `CompressorConfig.from_yaml()`

## Test plan
- [ ] Verify existing compression pipeline runs without errors (no code relied on quant path caching)
- [ ] Confirm transform path caching (rotate/reorder/smooth) is unaffected
- [ ] Validate all example YAML configs parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)